### PR TITLE
Separate rails root and cypress folders; rails 5 tweak

### DIFF
--- a/exe/cypress-rails
+++ b/exe/cypress-rails
@@ -3,7 +3,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require "pathname"
 require "cypress-rails"
-require Pathname.new(CypressRails::Config.new.dir).join("config/environment")
+require Pathname.new(CypressRails::Config.new.root).join("config/environment")
 
 command = ARGV[0]
 case command

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -2,10 +2,13 @@ require_relative "env"
 
 module CypressRails
   class Config
-    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+    attr_accessor :dir, :root, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
 
     def initialize(
+      # Root of cypress install if not in same as Rails root
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
+      # Root of Rails app
+      root: Env.fetch("CYPRESS_RAILS_ROOT", default: Dir.pwd),
       host: Env.fetch("CYPRESS_RAILS_HOST", default: "127.0.0.1"),
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
@@ -13,6 +16,7 @@ module CypressRails
       cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
     )
       @dir = dir
+      @root = root
       @host = host
       @port = port
       @base_path = base_path
@@ -26,6 +30,7 @@ module CypressRails
         cypress-rails configuration:
         ============================
          CYPRESS_RAILS_DIR.....................#{dir.inspect}
+         CYPRESS_RAILS_ROOT....................#{root.inspect}
          CYPRESS_RAILS_HOST....................#{host.inspect}
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -71,7 +71,9 @@ module CypressRails
       @legacy_saved_pool_configs ||= Hash.new { |hash, key| hash[key] = {} }
       @saved_pool_configs ||= Hash.new { |hash, key| hash[key] = {} }
 
-      ActiveRecord::TestFixtures.instance_method(:setup_shared_connection_pool).bind(self).call
+      # This only works with Rails 6.
+      # There is no `setup_shared_connection_pool` method in Rails 5 TextFixtures
+      # ActiveRecord::TestFixtures.instance_method(:setup_shared_connection_pool).bind(self).call
     end
   end
 end


### PR DESCRIPTION
* Added extra config in case the cypress folder isn't in the Rails root folder
* Comment out Rails 6 ActiveRecord::TestFixtures code for now